### PR TITLE
Add reset-to-menu helper and fallback currency rates

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram bot package."""
+
+from .routers import menu_router
+
+__all__ = ["menu_router"]

--- a/bot/routers/__init__.py
+++ b/bot/routers/__init__.py
@@ -1,0 +1,3 @@
+from .menu import router as menu_router
+
+__all__ = ["menu_router"]

--- a/bot/routers/menu.py
+++ b/bot/routers/menu.py
@@ -1,0 +1,14 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+
+from bot.utils.reset import reset_to_menu
+
+router = Router()
+
+
+@router.message(Command("menu"))
+async def show_menu(message: Message, state: FSMContext) -> None:
+    """Handler to reset state and show the main menu."""
+    await reset_to_menu(message, state)

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,0 +1,3 @@
+from .reset import reset_to_menu
+
+__all__ = ["reset_to_menu"]

--- a/bot/utils/reset.py
+++ b/bot/utils/reset.py
@@ -1,0 +1,8 @@
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+
+
+async def reset_to_menu(message: Message, state: FSMContext) -> None:
+    """Clear the current state and notify the user about returning to the menu."""
+    await state.clear()
+    await message.answer("Вы вернулись в главное меню.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ currency-converter-free
 PyYAML
 tabulate
 pytest
+
+aiogram

--- a/tks_api_official/calc.py
+++ b/tks_api_official/calc.py
@@ -200,6 +200,14 @@ class CustomsCalculator:
             return rate
         except Exception as e:
             logger.error(f"Currency conversion error: {e}")
+            # Fall back to simple static rates when the API is unreachable.
+            fallback_rates = {"EUR": 100.0, "USD": 90.0}
+            if currency in fallback_rates:
+                rate = amount * fallback_rates[currency]
+                logger.info(
+                    f"Used fallback rate for {currency}: {fallback_rates[currency]} RUB"
+                )
+                return rate
             return None
 
     def print_table(self, mode):


### PR DESCRIPTION
## Summary
- add `reset_to_menu` helper and router using it to return users to the main menu
- include `aiogram` dependency
- provide fallback currency rates to allow offline conversions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85d394e98832bb21cac321297fc6b